### PR TITLE
Support for gatsby@next

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Adds [`svg-react-loader`][loader] to gatsby webpack config (and removes `svg`s from the built-in `url-loader` config).
 
-`include` and `exclude` plugin options can be specified, if either is present then `svg-react-loader` will use them and `url-loader` will be reenabled with the inverse.
+The `rule` plugin option can be specified to pass [rule options](https://webpack.js.org/configuration/module/#rule).
 
 The following uses `svg-react-loader` to process svgs from a path matching `/assets/`, and `url-loader` to process svgs from everywhere else.
 
@@ -8,7 +8,9 @@ The following uses `svg-react-loader` to process svgs from a path matching `/ass
 {
     resolve: 'gatsby-plugin-react-svg',
     options: {
-        include: /assets/
+        rule: {
+          include: /assets/
+        }
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Adds [`svg-react-loader`][loader] to gatsby webpack config (and removes `svg`s from the built-in `url-loader` config).
 
-The `rule` plugin option can be specified to pass [rule options](https://webpack.js.org/configuration/module/#rule).
+The `rule` plugin option can be used to pass [rule options](https://webpack.js.org/configuration/module/#rule). If either `include` or `exclude` options are present, `svg-react-loader` will use them and `url-loader` will be reenabled with the inverse.
 
 The following uses `svg-react-loader` to process svgs from a path matching `/assets/`, and `url-loader` to process svgs from everywhere else.
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,43 +1,40 @@
-exports.modifyWebpackConfig = ({config, stage}, pluginOptions) => {
-	if ([
-		'develop',
-		'develop-html',
-		'build-html',
-		'build-javascript'
-	].includes(stage)) {
-		const { include, exclude } = pluginOptions;
-
-		// Remove svg from url-loader config
-		config.loader('url-loader', {
-			test: /\.(jpg|jpeg|png|gif|mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
-			loader: 'url-loader',
-			query: {
-				limit: 10000,
-				name: `static/[name].[hash:8].[ext]`,
-			}
-		});
-		
-		// Readd url-loader if in/excludes are specified
-		if (include || exclude) {
-			config.loader('url-loader-svg', {
-				test: /\.svg$/,
-				loader: 'url-loader',
-				query: {
-					limit: 10000,
-					name: `static/[name].[hash:8].[ext]`,
-				},
-				include: exclude,
-				exclude: include
-			});			
+exports.onCreateWebpackConfig = ({
+		stage, actions, getConfig, rules
+}, { rule: ruleProps = {} }) => {
+		if([
+				'develop',
+				'develop-html',
+				'build-html',
+				'build-javascript'
+		].includes(stage)) {
+				// Add the svg-react-loader rule
+				actions.setWebpackConfig({
+						module: {
+								rules: [
+										{
+												use: 'svg-react-loader',
+												test: /\.svg$/,
+												...ruleProps,
+										}
+								],
+						}
+				})
+				const cfg = getConfig()
+				const imgsRule = rules.images()
+				cfg.module.rules = [
+						// Remove the base url-loader images rule entirely
+						...cfg.module.rules.filter(rule => {
+								if(rule.test) {
+										return rule.test.toString() !== imgsRule.test.toString()
+								}
+								return true
+						}),
+						// Put it back without SVG loading
+						{
+								use: imgsRule.use,
+								test: new RegExp(imgsRule.test.toString().replace('svg|', '').slice(1, -1))
+						}
+				]
+				actions.replaceWebpackConfig(cfg)
 		}
-		
-		config.loader('svg-react-loader', {
-			test: /\.svg$/,
-			loader: 'svg-react-loader',
-			include,
-			exclude
-		});
-	}
-
-	return config;
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,40 +1,50 @@
 exports.onCreateWebpackConfig = ({
-		stage, actions, getConfig, rules
+	stage, actions, getConfig, rules
 }, { rule: ruleProps = {} }) => {
-		if([
-				'develop',
-				'develop-html',
-				'build-html',
-				'build-javascript'
-		].includes(stage)) {
-				// Add the svg-react-loader rule
-				actions.setWebpackConfig({
-						module: {
-								rules: [
-										{
-												use: 'svg-react-loader',
-												test: /\.svg$/,
-												...ruleProps,
-										}
-								],
-						}
-				})
-				const cfg = getConfig()
-				const imgsRule = rules.images()
-				cfg.module.rules = [
-						// Remove the base url-loader images rule entirely
-						...cfg.module.rules.filter(rule => {
-								if(rule.test) {
-										return rule.test.toString() !== imgsRule.test.toString()
-								}
-								return true
-						}),
-						// Put it back without SVG loading
-						{
-								use: imgsRule.use,
-								test: new RegExp(imgsRule.test.toString().replace('svg|', '').slice(1, -1))
-						}
-				]
-				actions.replaceWebpackConfig(cfg)
+	const { include, exclude } = ruleProps
+
+	if([
+		'develop',
+		'develop-html',
+		'build-html',
+		'build-javascript'
+	].includes(stage)) {
+		// Add the svg-react-loader rule
+		actions.setWebpackConfig({
+			module: {
+				rules: [
+					{
+						use: 'svg-react-loader',
+						test: /\.svg$/,
+						...ruleProps,
+					}
+				],
+			}
+		})
+		const cfg = getConfig()
+		const imgsRule = rules.images()
+
+		const newUrlLoaderRule = (include || exclude) ? {
+			...imgsRule,
+			include: exclude,
+			exclude: include
+		} : {
+			...imgsRule,
+			test: new RegExp(imgsRule.test.toString().replace('svg|', '').slice(1, -1))
 		}
+
+		cfg.module.rules = [
+			// Remove the base url-loader images rule entirely
+			...cfg.module.rules.filter(rule => {
+				if(rule.test) {
+					return rule.test.toString() !== imgsRule.test.toString()
+				}
+				return true
+			}),
+			// Put it back without SVG loading
+			newUrlLoaderRule
+		]
+		actions.replaceWebpackConfig(cfg)
+	}
 }
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-react-svg",
-  "version": "1.1.1",
+  "version": "2.0.0-beta1",
   "description": "Adds svg-react-loader to gatsby webpack config.",
   "main": "gatsby-node.js",
   "repository": {
@@ -14,6 +14,9 @@
     "gatsby-plugin"
   ],
   "author": "Jacob Mischka <jacob@mischka.me>",
+  "contributors": [
+    "Aaron Lampros (https://github.com/alampros)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/jacobmischka/gatsby-plugin-react-svg/issues"


### PR DESCRIPTION
This changes the API a bit - options are passed to the loader rule via `options.rule` property. This allows for passing other rule options (like `oneOf`) in addition to `include` & `exclude`.

Closes #4 