### PR TITLE
WIP filter removals

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,7 @@
 exports.onCreateWebpackConfig = ({
 	stage, actions, getConfig, rules
 }, { rule: ruleProps = {} }) => {
-	const { include, exclude } = ruleProps
+	const { include, exclude, filters = [], omitKeys, ...otherProps } = ruleProps
 
 	if([
 		'develop',
@@ -9,14 +9,33 @@ exports.onCreateWebpackConfig = ({
 		'build-html',
 		'build-javascript'
 	].includes(stage)) {
+        if (omitKeys && Array.isArray(omitKeys) && omitKeys.length) {
+            const removals = new RegExp(omitKeys.join('|'), 'i')
+
+            filters.push(function(value) {
+                Object.keys(value).forEach(function(key) {
+                    if (removals.test(key)) {
+                        delete value[key];
+                    }
+                 });
+            })
+        }
+
 		// Add the svg-react-loader rule
 		actions.setWebpackConfig({
 			module: {
 				rules: [
 					{
-						use: 'svg-react-loader',
-						test: /\.svg$/,
-						...ruleProps,
+                        test: /\.svg$/,
+                        include,
+                        exclude,
+                        ...otherProps,
+						use: {
+                            loader: 'svg-react-loader',
+                            options: {
+                                filters
+                            }
+                        },
 					}
 				],
 			}


### PR DESCRIPTION
updates config to allow options to be passed, and parsed through ruleProps then applied correctly to use loader config
specifically plucks includes, excludes, filters, and new key omitKeys to be used to setup svg-react-loader config
since filters are quite complex adds a simple key 'omitKeys' to allow end users to quickly remove keys that are problematic from their svg files
lets filters remain in place if they are passed in directly
allows config to define its own filters per the docs