### PR TITLE
Allow passing query params to react-svg-loader via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ The following configuration uses `svg-react-loader` to process SVGs from a path 
 
 ```js
 {
-    resolve: 'gatsby-plugin-react-svg',
-    options: {
-        rule: {
-          include: /assets/
-        }
+  resolve: 'gatsby-plugin-react-svg',
+  options: {
+    rule: {
+      include: /assets/
     }
+  }
 }
 ```
 
@@ -59,12 +59,12 @@ Another common configuration:
 
 ```js
 {
-    resolve: 'gatsby-plugin-react-svg',
-    options: {
-        rule: {
-          include: /\.inline\.svg$/
-        }
+  resolve: 'gatsby-plugin-react-svg',
+  options: {
+    rule: {
+      include: /\.inline\.svg$/
     }
+  }
 }
 ```
 
@@ -84,6 +84,56 @@ In styles file:
 .header-background {
   background-image: url(./path/something.svg);
 }
+```
+
+### SVG-React-Loader options
+
+Any of the svg-react-loader [query parameters](https://github.com/jhamlet/svg-react-loader#query-params) can be passed down via the webpack config by including an `options` prop within the `rule` prop.
+
+```js
+// In your gatsby-config.js
+
+plugins: [
+  {
+    resolve: "gatsby-plugin-react-svg",
+      options: {
+        rule: {
+          include: /\.inline\.svg$/,
+          options: {
+            tag: "symbol",
+            name: "MyIcon",
+            props: {
+              className: "my-class",
+              title: "example"
+            },
+            filters: [value => console.log(value)]
+          }
+        }
+      }
+  }
+];
+```
+They can also be defined at the import level:
+
+```js
+  import Fork from "-!svg-react-loader?props[]=className:w-4 h-4!../components/Icons/Fork.inline.svg";
+```
+
+### Removing svg props (filters)
+Unwanted SVG props can be removed with filters. Since filters are quite complex this plugin adds a simple key `omitKeys` to allow end users to quickly remove props that are problematic from their svg files.
+
+```js
+{
+  resolve: `gatsby-plugin-react-svg`,
+  options: {
+    rule: {
+      include: /images\/.*\.svg/,
+      omitKeys: ['xmlnsDc', 'xmlnsCc', 'xmlnsRdf', 'xmlnsSvg', 'xmlnsSodipodi', 'xmlnsInkscape']
+      ///OR
+      filters: [(value) => { console.log(value); }]
+    }
+  }
+},
 ```
 
 ## Troubleshooting

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,7 +11,7 @@ exports.onCreateWebpackConfig = ({
 	].includes(stage)) {
 		if (omitKeys && Array.isArray(omitKeys) && omitKeys.length) {
 				const removals = new RegExp(omitKeys.join('|'), 'i')
-				if (!Array.isArray(option.filters)) {
+				if (!Array.isArray(options.filters)) {
 					options.filters = []
 				}
 				options.filters.push(function(value) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,42 +1,41 @@
 exports.onCreateWebpackConfig = ({
 	stage, actions, getConfig, rules
 }, { rule: ruleProps = {} }) => {
-	const { include, exclude, filters = [], omitKeys, options = {}, ...otherProps } = ruleProps
-	
+	const { include, exclude, omitKeys, options = {}, ...otherProps } = ruleProps
+
 	if([
 		'develop',
 		'develop-html',
 		'build-html',
 		'build-javascript'
 	].includes(stage)) {
-        if (omitKeys && Array.isArray(omitKeys) && omitKeys.length) {
-            const removals = new RegExp(omitKeys.join('|'), 'i')
-
-            filters.push(function(value) {
-                Object.keys(value).forEach(function(key) {
-                    if (removals.test(key)) {
-                        delete value[key];
-                    }
-                });
-            })
-        }
+		if (omitKeys && Array.isArray(omitKeys) && omitKeys.length) {
+				const removals = new RegExp(omitKeys.join('|'), 'i')
+				if (!Array.isArray(option.filters)) {
+					options.filters = []
+				}
+				options.filters.push(function(value) {
+						Object.keys(value).forEach(function(key) {
+								if (removals.test(key)) {
+										delete value[key];
+								}
+						});
+				})
+		}
 
 		// Add the svg-react-loader rule
 		actions.setWebpackConfig({
 			module: {
 				rules: [
 					{
-                        test: /\.svg$/,
-                        include,
-                        exclude,
-                        ...otherProps,
+						test: /\.svg$/,
+						include,
+						exclude,
+						...otherProps,
 						use: {
-                            loader: 'svg-react-loader',
-                            options: {
-																filters,
-																...options
-                            }
-                        },
+							loader: 'svg-react-loader',
+							options
+						},
 					}
 				],
 			}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,8 +1,8 @@
 exports.onCreateWebpackConfig = ({
 	stage, actions, getConfig, rules
 }, { rule: ruleProps = {} }) => {
-	const { include, exclude, filters = [], omitKeys, ...otherProps } = ruleProps
-
+	const { include, exclude, filters = [], omitKeys, options = {}, ...otherProps } = ruleProps
+	
 	if([
 		'develop',
 		'develop-html',
@@ -17,7 +17,7 @@ exports.onCreateWebpackConfig = ({
                     if (removals.test(key)) {
                         delete value[key];
                     }
-                 });
+                });
             })
         }
 
@@ -33,7 +33,8 @@ exports.onCreateWebpackConfig = ({
 						use: {
                             loader: 'svg-react-loader',
                             options: {
-                                filters
+																filters,
+																...options
                             }
                         },
 					}


### PR DESCRIPTION
I'd like to be able to pass any of the query-params available from gatsby plugin to [svg-react-loader](https://github.com/jhamlet/svg-react-loader#query-params) from the loader config. From looking at the README and the source code I can't understand how this is done. From what I've understood I can pass certain params  (e.g. filters) but not all options are catered for.

This PR adds the ability to use any of the query params available on svg-react-loader. It also adds some explanation on how to use this feature along with omitKeys prop.
