### PR TITLE
hints for using with typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ In styles file:
 }
 ```
 
+## Using with typescript
+
+To use SVGs with Typescript, create a custom type definition like this:
+
+```typescript
+declare module "*.svg" {
+  const content: any;
+  export default content;
+}
+```
+
+Make sure the file is contained in your `tsconfig.json` `include`.
+
 ### SVG-React-Loader options
 
 Any of the svg-react-loader [query parameters](https://github.com/jhamlet/svg-react-loader#query-params) can be passed down via the webpack config by including an `options` prop within the `rule` prop.


### PR DESCRIPTION
Hey,

thanks a lot for providing this plugin. I had a bit of a hard time using it with Typescript though, until I found [this post on SO](https://stackoverflow.com/questions/44717164/unable-to-import-svg-files-in-typescript). 

Although it's not strictly related to your plugin, I think it would be nice to have a short passage about it in the readme. I think there might be more people like me who want to start using Gatsby with Typescript, and don't have prior experience with having to setup the Typescript-SVG bit themselves.

Please see if you agree, and feel free to modify as you see fit.

Peace
