### PR TITLE
fix: Set peerDependency on gatsby

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "homepage": "https://github.com/jacobmischka/gatsby-plugin-react-svg#readme",
   "dependencies": {
     "svg-react-loader": "^0.4.4"
+  },
+  "peerDependencies": {
+    "gatsby": "^3.0.0 || ^2.0.0"
   }
 }


### PR DESCRIPTION
Hello @jacobmischka, Gatsby maintainer here 👋 

While looking at your plugin I noticed that the `peerDependency` on `gatsby` is not set. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

Setting the peerDep will allow us to display the plugin as compatible to versions X, Y, Z.

Thanks!