### PR TITLE
Resolve proper path to the loader.

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -33,7 +33,7 @@ exports.onCreateWebpackConfig = ({
 						exclude,
 						...otherProps,
 						use: {
-							loader: 'svg-react-loader',
+							loader: require.resolve('svg-react-loader'),
 							options
 						},
 					}


### PR DESCRIPTION
Hi, I had an issue with PNPM in monorepo where webpack couldn't find the `svg-react-loader`. This fix ensures that webpack picks up the proper loader.